### PR TITLE
Support for Laravel 5.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     "minimum-stability": "stable",
     "require": {
         "php" : ">=7.0",
-        "illuminate/auth": "~5.4.0",
-        "illuminate/container": "~5.4.0",
-        "illuminate/contracts": "~5.4.0",
-        "illuminate/database": "~5.4.0",
-        "illuminate/filesystem": "^5.4"
+        "illuminate/auth": "~5.5.0",
+        "illuminate/container": "~5.5.0",
+        "illuminate/contracts": "~5.5.0",
+        "illuminate/database": "~5.5.0",
+        "illuminate/filesystem": "^5.5"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
-        "laravel/laravel": "^5.4",
-        "backpack/base": "^0.7.21"
+        "laravel/laravel": "^5.5",
+        "backpack/base": "^0.8.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
All packages are updated to versions supporting Laravel 5.5

I tried installing my fork on a fresh Laravel 5.5 project and all generators worked just fine.